### PR TITLE
[BUGFIX] Umlauts in search (utf8)

### DIFF
--- a/Classes/Domain/Model/Document.php
+++ b/Classes/Domain/Model/Document.php
@@ -249,7 +249,7 @@ class Document extends \Zend_Search_Lucene_Document
     /**
      * Return the unserialized document reference parameters
      *
-     * @return string                    Document reference parameters
+     * @return array                    Document reference parameters
      */
     public function getReferenceParameters()
     {
@@ -296,6 +296,9 @@ class Document extends \Zend_Search_Lucene_Document
     {
         $referenceParams = $this->getReferenceParameters();
         unset($referenceParams['id']);
+        if (!$referenceParams['type']) {
+            unset($referenceParams['type']);
+        }
         return $referenceParams;
     }
 

--- a/Classes/Service/Lucene.php
+++ b/Classes/Service/Lucene.php
@@ -543,7 +543,7 @@ class Lucene extends \TYPO3\CMS\Core\Service\AbstractService implements \TYPO3\C
                     $tokenTerms[] = $token;
                     $isPhrase = ($token->type == \Zend_Search_Lucene_Search_QueryToken::TT_PHRASE);
                     $tokenStr = $isPhrase ? '"'.$token->text.'"' : $token->text;
-                    $tokenStrLength = strlen($tokenStr);
+                    $tokenStrLength = mb_strlen($tokenStr);
 
                     // Apply external rewriters
                     if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tw_lucenesearch']['term-rewrite-hooks'])) {
@@ -575,8 +575,8 @@ class Lucene extends \TYPO3\CMS\Core\Service\AbstractService implements \TYPO3\C
                         $tokenRewrite[] = $sfTokenStr;
                     }
                     $tokenRewrite = '('.implode(' OR ', $tokenRewrite).')';
-                    $searchTerm = substr($searchTerm, 0,
-                            $token->position - $tokenStrLength).$tokenRewrite.substr($searchTerm,
+                    $searchTerm = mb_substr($searchTerm, 0,
+                            $token->position - $tokenStrLength).$tokenRewrite.mb_substr($searchTerm,
                             $token->position);
                 }
             }


### PR DESCRIPTION
Fixes a problem with umlauts in Searches.

For example if i searched "Lösungen" i would get results with only "n", because the searchterm would be rewritten to `Lösunge(title:Lösungen*^2 OR keywords:Lösungen*^1.6 OR abstract:Lösungen~0.5^1.2 OR bodytext:Lösungen~0.5)n`